### PR TITLE
feat: added _id handling in Handler for post requests, moved issue filtering and data formatting to the Handler 

### DIFF
--- a/dao/issues-dao.js
+++ b/dao/issues-dao.js
@@ -1,18 +1,8 @@
 const { log, warn, error } = console,
   { env } = process
-
 const { ObjectId } = require('mongodb'),
   COLLECTION = env.NODE_ENV === 'dev' ? 'test' : 'projects'
 let db
-/**
- * @description A utility function to generate UTC date strings from the current date.
- * @returns {string} A UTC string of the current date.
- */
-function now() {
-  return new Date().toUTCString()
-}
-
-// Test comment for push.
 
 // 📄 I don't yet know the difference between declaring owners as a global variable in this file (the current setup), and declaring it as a property in the IssuesDAO class.
 module.exports = class IssuesDAO {
@@ -68,22 +58,18 @@ module.exports = class IssuesDAO {
    * @description Creates an upsert call to the db with the project argument passed. For testing purposes.
    * @async
    * @param {Project} project The document to be upserted into the collection.
-   * @returns {object | null} The collection.updateOne response object, if the attempt was successful, or an object containing an error property if the attempt failed.
+   * @returns {object | null} The collection.updateOne response, or an object containing an error property if the attempt failed.
    */
   static async putProject(project) {
-    const filter = { _id: project._id },
+    const query = { name: project.name },
       operators = { $set: { ...project } },
       options = { upsert: true }
-    if (Array.isArray(project?.issues))
-      for (const issue of project.issues) {
-        const rightNow = now()
-        if (issue.created_on === undefined) issue.created_on = rightNow
-        issue.last_updated = rightNow
-      }
     let result
 
+    log(query, operators, options)
+
     try {
-      result = await db.updateOne(filter, operators, options)
+      result = await db.updateOne(query, operators, options)
     } catch (err) {
       error(`\x1b[31m\nerror updating ${COLLECTION} collection:`, err)
       return { error: err.message }
@@ -93,37 +79,12 @@ module.exports = class IssuesDAO {
   }
 
   /**
-   * @description Attempts to fetch any documents from the connected collection matching the passed filter fields.
+   * @description Attempts to fetch a single Project document matching the passed project name.
    * @async
    * @param {string} name The name of the project.
-   * @param {object} query An object containing the query params from the url.
    * @returns {{ err: string } | Project | null} An object containing an error property if the find method fails, or a document or null depending on whether a match was found.
    */
-  static async getProject(name, issueQueries) {
-    /**
-     * @description Returns a new array, containing only the issues that matched all the queries.
-     * @param {array} issues The issues to filter.
-     * @param {object} queries The queries to filter the issues with.
-     */
-    function filterIssues(issues = [], queries = {}) {
-      const queryKeys = Object.keys(queries)
-      // To prevent data mutation and keep this function "pure", we create a copy of issues with the spread operator instead of acting on the parameter, since the Array.filter method creates a shallow copy of the array argument, which can lead to unexpected behaviour.
-      return [...issues].filter(issue => {
-        for (const key of queryKeys) {
-          const query = queries[key],
-            issueField = issue[key]
-
-          // (typeof query === 'string' && !issueField.includes(query))
-          if (
-            (query === null && issueField !== null) ||
-            (typeof query === 'string' &&
-              !issueField.match(new RegExp(query, 'i')))
-          )
-            return false
-        }
-        return true
-      })
-    }
+  static async getProject(name) {
     // I will filter the issues array after finding a match, but will keep in mind the possibility of integrating the pipeline for this functionality - maybe reformat the document structure to each individually represent an issue, and have the collection represent the project?
     const query = { name }
     let result
@@ -135,14 +96,6 @@ module.exports = class IssuesDAO {
       return { error: err.message }
     }
 
-    if (
-      Array.isArray(result?.issues) &&
-      issueQueries !== null &&
-      typeof issueQueries === 'object' &&
-      Object.keys(issueQueries).length > 0
-    )
-      result.issues = filterIssues(result.issues, issueQueries)
-
     return result
   }
 
@@ -150,15 +103,20 @@ module.exports = class IssuesDAO {
    * @description Attempts to post (update) the passed object to the connected collection.
    * @async
    * @param {Project} project The object to post to the respective collection.
+   * @returns {null | { error: string } | { acknowledged: string, insertedId: string | null | undefined }}
    */
   static async postProject(project) {
+    const { _id } = project
+
+    if (_id !== undefined)
+      return {
+        error: `unexpected _id property of type ${typeof _id} on project argument - _id is automatically supplied`,
+      }
+    project._id = new ObjectId()
+
     if (Array.isArray(project?.issues))
       for (const issue of project.issues)
         issue.created_on = new Date().toUTCString()
-
-    if (project._id !== undefined)
-      warn(`overriding _id property on project of type ${typeof project._id}`)
-    project._id = new ObjectId()
 
     let result
 

--- a/dao/issues-dao.js
+++ b/dao/issues-dao.js
@@ -66,8 +66,6 @@ module.exports = class IssuesDAO {
       options = { upsert: true }
     let result
 
-    log(query, operators, options)
-
     try {
       result = await db.updateOne(query, operators, options)
     } catch (err) {
@@ -100,24 +98,12 @@ module.exports = class IssuesDAO {
   }
 
   /**
-   * @description Attempts to post (update) the passed object to the connected collection.
+   * @description Attempts to post (upload) the passed object to the connected collection.
    * @async
    * @param {Project} project The object to post to the respective collection.
    * @returns {null | { error: string } | { acknowledged: string, insertedId: string | null | undefined }}
    */
   static async postProject(project) {
-    const { _id } = project
-
-    if (_id !== undefined)
-      return {
-        error: `unexpected _id property of type ${typeof _id} on project argument - _id is automatically supplied`,
-      }
-    project._id = new ObjectId()
-
-    if (Array.isArray(project?.issues))
-      for (const issue of project.issues)
-        issue.created_on = new Date().toUTCString()
-
     let result
 
     try {

--- a/dev/ignore.js
+++ b/dev/ignore.js
@@ -1,40 +1,15 @@
 console.clear()
 const { log, error } = console
 
-function isWholeNum(num) {
-  return num % 1 === 0
+const obj = {
+  _id: 'abc',
+  b: 'b  ',
+  c: null,
+  d: 2,
 }
 
-// Iterate from 1 to the number passed, rounded down.
-// For each of those numbers, log the number divided by that number as well.
-function factor(num, sum) {
-  for (let denom = 1; denom < Math.floor(num / 2); denom++) {
-    const rem = num / denom
+log(obj, 'BEFORE')
 
-    if (!isWholeNum(rem)) continue
+delete obj._id
 
-    log(denom, rem)
-  }
-}
-
-const date = new Date(),
-  strFromDate = date.toString()
-let dateFromStr
-// setTimeout(() => {
-//   dateFromStr = new Date(strFromDate)
-//   log(date)
-//   log(strFromDate)
-//   log(dateFromStr)
-// }, 2000)
-
-// I'm hoping that dateFromStr will be the same as date; this would mean I can switch from date instances to date strings, and back.
-
-// log(date)
-// log(date.toDateString())
-// log(date.toTimeString())
-// log(date.toUTCString())
-
-const { ObjectId } = require('mongodb'),
-  _id0 = new ObjectId()
-
-log(typeof _id0, _id0)
+log(obj, 'AFTER')

--- a/dev/notes.txt
+++ b/dev/notes.txt
@@ -59,18 +59,12 @@
   📄 query contains the '...?KEY=VALUE' pairs of a path
   📄 params contain sections of the url that are mapped to certain variables, e.g. 'api/issues/:owner', req.param would contain a variable "owner" with the value pertaining to the string that was in the respective url position at the time of the request. 
 
-- ⚒️🎉 integrate all the changes from repl.it
+- ✅ integrate all the changes from repl.it
   📄 these are meant to ensure the DAO ONLY makes DB requests, and that the handler does data formatting/manipulating (e.g. responding with the desired structure)
-  - ✅ check if the PUT request tests are passing
-    📄 suiteSetup 2 & 3 tests are FAILING
-  - ✅ check what is going wrong in each failing test
-    📄 suiteSetup 2 is reading the length property of NULL
-    📄 suiteSetup 3 is receiving NULL where it expected an ARRAY
-  - ⚒️✅ fix the issues listed above
-    - ✅ suiteSetup2:
-    - ✅ suiteSetup 3:
-  - 🎉 verify the DAO methods are not doing any data handling
+  - ✅ verify the DAO methods are not doing any data handling
     📄 should I keep the filterIssues function in the getProject method? I guess not, since I decided to make the DAO method ONLY make db requests; filtering out data is data handling, which will for now go in the handler.
+  - ✅ implement the data handling that was previously in the DAO, in the Handler
+    📄 Note for future self: be wary of spaghetti code; functions that call other functions in a disorderly manner. Won't worry about it now, but just be wary.
 
 - ⚒️ Red, green, refactor: all of the functional tests in tests/issue-tracker.test.js:
   - ✅ Create an issue with every field: POST request to /api/issues/:project
@@ -111,15 +105,11 @@
   - ✅ commit & push
   - ✅ check if a new post request generates a document with an ObjectId, or if not, how we can configure the db to handle that itself. If not, I can add the property automatically.
   - ✅ fix failing tests
-  - finish fixing _id functionality on the api
+  - ✅ finish fixing _id functionality on the api
     - ✅ decide what should be done when a post request document contains an _id property
       📄 I'll respond with a bad request (http code 400) with a message "_id property supplied"
-    - code for the functionality above (including put requests)
-    - write a post test, with an object containing an _id property, and assert an object containing an error property with a value of type string is returned
-  - 🎉 edit hndler nd dao methods
     📄 any data shaping should be handled by the handler, and the DAO will simply make a request to the database with the document passed.
-    📄 consider using middlewar
-  - 🎉 finish fixing _id functionality on the api
+  - 🎉 commit, push, merge with main, deploy to heroku
   - Update one field on an issue: PATCH request to /api/issues/{project}
     📄 Before updating an issue, I need to know WHICH issue to update. 
       One way to do this is to reformat my db to store only SINGLE issues, in collections that pertain to different projects.

--- a/dev/notes.txt
+++ b/dev/notes.txt
@@ -59,7 +59,20 @@
   📄 query contains the '...?KEY=VALUE' pairs of a path
   📄 params contain sections of the url that are mapped to certain variables, e.g. 'api/issues/:owner', req.param would contain a variable "owner" with the value pertaining to the string that was in the respective url position at the time of the request. 
 
-- ⚒️🎉 Red, green, refactor; all of the functional tests in tests/issue-tracker.test.js:
+- ⚒️🎉 integrate all the changes from repl.it
+  📄 these are meant to ensure the DAO ONLY makes DB requests, and that the handler does data formatting/manipulating (e.g. responding with the desired structure)
+  - ✅ check if the PUT request tests are passing
+    📄 suiteSetup 2 & 3 tests are FAILING
+  - ✅ check what is going wrong in each failing test
+    📄 suiteSetup 2 is reading the length property of NULL
+    📄 suiteSetup 3 is receiving NULL where it expected an ARRAY
+  - ⚒️✅ fix the issues listed above
+    - ✅ suiteSetup2:
+    - ✅ suiteSetup 3:
+  - 🎉 verify the DAO methods are not doing any data handling
+    📄 should I keep the filterIssues function in the getProject method? I guess not, since I decided to make the DAO method ONLY make db requests; filtering out data is data handling, which will for now go in the handler.
+
+- ⚒️ Red, green, refactor: all of the functional tests in tests/issue-tracker.test.js:
   - ✅ Create an issue with every field: POST request to /api/issues/:project
   - ✅ commit & push
   - ✅ Create an issue with only required fields: POST request to /api/issues/{project}
@@ -71,7 +84,7 @@
     - ✅ modify GET handler to only return the issues array
   - ✅ commit & push
   - ✅ View issues on a project with one filter: GET request to /api/issues/{project}
-    📄 pseudocode for filtering db response issues:
+    -✅ pseudocode for filtering db response issues:
       - if response is NOT null ✅, and issueQueries has at LEAST one key ✅, and the response has an issues property of type array ✅:
         - iterate through each issue in the issues array ✅. For each issue:
           - map through the keys of issueQueries, ensuring the respective key in the current issue matches the value of the same key in the issueQueries parameter ✅
@@ -98,7 +111,11 @@
   - ✅ commit & push
   - ✅ check if a new post request generates a document with an ObjectId, or if not, how we can configure the db to handle that itself. If not, I can add the property automatically.
   - ✅ fix failing tests
-  - 🎉 finish fixing _id functionality on the api
+  - finish fixing _id functionality on the api
+    - ✅ decide what should be done when a post request document contains an _id property
+      📄 I'll respond with a bad request (http code 400) with a message "_id property supplied"
+    - code for the functionality above (including put requests)
+    - write a post test, with an object containing an _id property, and assert an object containing an error property with a value of type string is returned
   - Update one field on an issue: PATCH request to /api/issues/{project}
     📄 Before updating an issue, I need to know WHICH issue to update. 
       One way to do this is to reformat my db to store only SINGLE issues, in collections that pertain to different projects.
@@ -120,6 +137,10 @@
   - Delete an issue with an invalid _id: DELETE request to /api/issues/{project}
   - commit & push
   - Delete an issue with missing _id: DELETE request to /api/issues/{project}
+
+- verify that DAO errors are SERVER errors: all client errors (bad requests) should be handled in the handler.
+
+- rename the document property "name" to "project"
 
 - ⚒️ Complete the necessary routes in /routes/api.js for the /api/issues/{project}?open=true&assigned_to=Joe route:
   - get an issue, with the option to filter using asignees, reactions, or other things

--- a/tests/issue-tracker.test.js
+++ b/tests/issue-tracker.test.js
@@ -1,10 +1,9 @@
 'use strict'
+const { log } = console
 function now() {
   return new Date().toUTCString()
 }
-
 const chaiHttp = require('chai-http'),
-  { ObjectId } = require('mongodb'),
   chai = require('chai'),
   server = require('../server.js'),
   { assert } = chai,
@@ -22,7 +21,6 @@ const chaiHttp = require('chai-http'),
     ],
   },
   TEST_DOC2 = {
-    _id: '12345',
     name: 'huberman_lab_transcripts',
     owner: 'solarc117',
     issues: [
@@ -57,7 +55,6 @@ const chaiHttp = require('chai-http'),
     ],
   },
   TEST_DOC3 = {
-    _id: new ObjectId('0000000197d9af3844c5dc92'),
     name: 'python-algs',
     owner: 'fcc_learner_:)',
     issues: [],
@@ -136,6 +133,8 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       .get(setup2Path)
       .end((err, res) => {
         const { status, ok, body: issues } = res
+
+        log(issues)
 
         assert.isNull(err)
         assert.strictEqualPairs([status, 200], [issues.length, 4])

--- a/tests/issue-tracker.test.js
+++ b/tests/issue-tracker.test.js
@@ -134,8 +134,6 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       .end((err, res) => {
         const { status, ok, body: issues } = res
 
-        log(issues)
-
         assert.isNull(err)
         assert.strictEqualPairs([status, 200], [issues.length, 4])
         assert.isTrue(ok)
@@ -198,7 +196,7 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       ],
     },
     test2Path = `${ISSUES}/${newProject.name}`
-  test(`2. POST ${test2Path} (every field)`, done => {
+  test(`2. create with every field except _id: POST ${test2Path}`, done => {
     chai
       .request(server)
       .post(test2Path)
@@ -228,7 +226,7 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       ],
     },
     test3Path = `${ISSUES}/${newProject2.name}`
-  test(`3. POST ${test3Path} (only required fields)`, done => {
+  test(`3. create with only required fields: POST ${test3Path}`, done => {
     chai
       .request(server)
       .post(test3Path)
@@ -249,19 +247,19 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       })
   })
 
-  const newProject3 = {
+  const newProject4 = {
       name: 'react-calculator',
       issues: [],
     },
-    test4Path = `${ISSUES}/${newProject3.name}`
-  test(`4. POST ${test4Path} (missing required fields)`, done => {
+    test4Path = `${ISSUES}/${newProject4.name}`
+  test(`4. create with missing required fields: POST ${test4Path}`, done => {
     chai
       .request(server)
       .post(test4Path)
-      .send(newProject3)
+      .send(newProject4)
       .end((err, res) => {
         const { status, ok, body } = res,
-          { err: error } = body
+          { error } = body
 
         assert.isNull(err)
         assert.strictEqual(status, 400)
@@ -272,11 +270,38 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       })
   })
 
-  const test5Path = `${ISSUES}/${TEST_DOC1.name}`
-  test(`5. GET ${test5Path}`, done => {
+  const user5 = 'random_coder',
+    newProject5 = {
+      _id: 123456,
+      name: 'js website',
+      owner: user5,
+      issues: [],
+    },
+    test5Path = `${ISSUES}/${newProject5.name}`
+  test(`5. include _id: POST ${test5Path}`, done => {
     chai
       .request(server)
-      .get(test5Path)
+      .post(test5Path)
+      .send(newProject5)
+      .end((err, res) => {
+        const { status, ok, body } = res,
+          { error } = body
+
+        assert.isNull(err)
+        assert.strictEqual(status, 400)
+        assert.isFalse(ok)
+        assert.isString(error)
+        assert.include(error, '_id')
+
+        done()
+      })
+  })
+
+  const test6Path = `${ISSUES}/${TEST_DOC1.name}`
+  test(`6. GET ${test6Path}`, done => {
+    chai
+      .request(server)
+      .get(test6Path)
       .end((err, res) => {
         const { status, ok, body: issues } = res,
           issue = issues[0],
@@ -303,12 +328,12 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       })
   })
 
-  const test6Params = '?assigned_to',
-    test6Path = `${ISSUES}/${TEST_DOC2.name}${test6Params}`
-  test(`6. view issues with one filter: GET ${test6Path}`, done => {
+  const test7Params = '?assigned_to',
+    test7Path = `${ISSUES}/${TEST_DOC2.name}${test7Params}`
+  test(`7. view issues with one filter: GET ${test7Path}`, done => {
     chai
       .request(server)
-      .get(test6Path)
+      .get(test7Path)
       .end((err, res) => {
         const { status, ok, body: issues } = res,
           {
@@ -330,12 +355,12 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       })
   })
 
-  const test7Params = '?title=podcast&assigned_to=sol',
-    test7Path = `${ISSUES}/${TEST_DOC2.name}${test7Params}`
-  test(`7. view issues with multiple filters: GET ${test7Path}`, done => {
+  const test8Params = '?title=podcast&assigned_to=sol',
+    test8Path = `${ISSUES}/${TEST_DOC2.name}${test8Params}`
+  test(`8. view issues with multiple filters: GET ${test8Path}`, done => {
     chai
       .request(server)
-      .get(test7Path)
+      .get(test8Path)
       .end((err, res) => {
         // I might want to consider using optional chaining, if destructuring from an undefined value causes my site to crash - ex:
         // issue = issues?.[0]
@@ -353,8 +378,8 @@ suite('🧪 \x1b[34mIssue Tracker: HTTP', () => {
       })
   })
 
-  const test8Path = `${ISSUES}/${TEST_DOC1.name}`
-  test(`8. update one field: PATCH ${test8Path}`, done => {
+  const test9Path = `${ISSUES}/${TEST_DOC1.name}`
+  test(`9. update one field: PATCH ${test9Path}`, done => {
     const updateObj = {
       _id: TEST_DOC1._id,
     }


### PR DESCRIPTION
Post requests to /api/issues/:project return an object with an error property if the document sent contains an _id property.

Moved data handling to the Handler; DAO now only makes db requests and handles server errors.